### PR TITLE
Update mod metadata

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -8,7 +8,7 @@ org.gradle.jvmargs=-Xmx2G
 	loader_version=0.12.6
 
 # Mod Properties
-	mod_version = 1.0.1
+	mod_version = 1.2.1
 	maven_group = net.shulker.dupe
 	archives_base_name = shulker-dupe
 

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -9,12 +9,10 @@
     "Coderx_Gamer"
   ],
   "contact": {
-    "homepage": "https://fabricmc.net/",
-    "sources": "https://github.com/FabricMC/fabric-example-mod"
+    "homepage": "https://github.com/Coderx-Gamer/shulker-dupe",
+    "sources": "https://github.com/Coderx-Gamer/shulker-dupe",
+    "issues": "https://github.com/Coderx-Gamer/shulker-dupe"
   },
-
-  "license": "CC0-1.0",
-  "icon": "assets/shulker-dupe/icon.png",
 
   "environment": "client",
   "entrypoints": {


### PR DESCRIPTION
- Removed Fabric placeholder information
- Added actual mod information where available
- Fixed wrong mod version number

I'm not sure if you wanted the mod to be licensed as public domain since you didn't select a license on GitHub, so I removed that from the metadata. I can add it back if it was intentional. Related to #25.